### PR TITLE
Invert bg and text colors

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -10,7 +10,7 @@ import Contact from 'pages/Contact'
 function App() {
 
   return (
-    <div className="relative bg-gray-900 min-h-screen m-0">
+    <div className="relative bg-gray-100 min-h-screen m-0">
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Home />} />

--- a/src/components/CategoryCard.jsx
+++ b/src/components/CategoryCard.jsx
@@ -10,11 +10,11 @@ const CategoryCard = (props) => {
     startTime,
   } = props
 
-  const style = "bg-gray-900 rounded-xl m-2"
+  const style = "bg-gray-100 shadow-inner rounded-xl m-3"
   
   return (
     <div className={style}>
-      <div className="bg-gradient-to-b from-gray-700 to-transparent rounded-t-xl">
+      <div className="rounded-t-xl">
         <H3>{name}</H3>
       </div>
       <div className="p-2">

--- a/src/components/CategoryContainer.jsx
+++ b/src/components/CategoryContainer.jsx
@@ -1,7 +1,7 @@
 import CategoryCard from 'components/CategoryCard'
 
 const CategoryContainer = () => {
-  const style = "md:flex bg-gradient-to-r from-red-500 to-red-800 rounded-xl p-2 my-4"
+  const style = "md:flex bg-gradient-to-r from-red-400 to-red-700 shadow-lg rounded-xl p-2 my-4"
   
   return (
     <div className={style}>

--- a/src/components/CtaButton.jsx
+++ b/src/components/CtaButton.jsx
@@ -1,5 +1,5 @@
-const CtaButton = () => {
-  const style = "inline-block text-2xl px-4 py-2 my-2 leading-none border rounded text-white font-heading border-white -skew-x-6 hover:border-transparent hover:text-teal-500 hover:bg-white"
+const CtaButton = ({ dark }) => {
+  const style = `inline-block text-2xl px-4 py-2 my-2 leading-none border rounded ${dark ? 'text-black border-black drop-shadow-md hover:bg-red-500 hover:text-gray-100' : 'text-gray-100 border-gray-100 hover:bg-gray-100 hover:text-red-500'} font-heading -skew-x-6 hover:border-transparent`
 
   return (
     <div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -3,17 +3,17 @@ import logo from 'assets/white_pepper.svg'
 
 const Footer = () => {
   const wrapperStyle = "absolute bottom-0 w-screen"
-  const footerStyle = "flex justify-center items-center h-20 text-center text-white bg-gradient-to-r from-red-500 to-red-800"
+  const footerStyle = "flex justify-center items-center h-20 text-center text-gray-100 bg-gradient-to-r from-red-400 to-red-700"
 
   return (
     <div className={wrapperStyle}>
       <img
-        className="mx-auto my-8 h-80"
+        className="mx-auto my-8 h-80 drop-shadow-lg"
         src={logo} 
         alt="Outline of white pepper in the shape of the course"
       />
       <footer className={footerStyle}>
-        <P>
+        <P light>
           ©2023 Carolina Reaper Road Race 
         </P>
       </footer>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -34,7 +34,7 @@ const Header = () => {
 
   return (
     <header className={`sticky ${showHeader ? 'top-0' : '-top-[500px]'} font-heading transition-all duration-300 ease-in-out z-50`}>
-      <nav className="flex items-center justify-between flex-wrap bg-gradient-to-r from-red-500 to-red-800 p-3 pr-6">
+      <nav className="flex items-center justify-between flex-wrap bg-gradient-to-r from-red-400 to-red-700 p-3 pr-6">
         <div className="flex items-center flex-shrink-0 text-white sm:mr-12">
           <img className="h-20 mr-4" src={logo} alt="a white outline of a Carolina Reaper pepper in the shape of the race course with a green stem" />
           <span className="text-xl font-logo md:text-2xl italic tracking-tight">CAROLINA REAPER<br /> ROAD RACE</span>

--- a/src/components/markup/H1.jsx
+++ b/src/components/markup/H1.jsx
@@ -1,5 +1,5 @@
 const H1 = ({ children }) => {
-  const style = "text-5xl font-heading pt-4"
+  const style = "text-5xl text-gray-900 drop-shadow-md font-heading pt-4"
   
   return (
     <h1 className={style}>

--- a/src/components/markup/H2.jsx
+++ b/src/components/markup/H2.jsx
@@ -1,5 +1,5 @@
 const H2 = ({ children, id }) => {
-  const style = "text-3xl font-heading bg-gradient-to-r from-red-500 to-red-800 -skew-x-6 mb-4 mt-8 p-3"
+  const style = "text-3xl font-heading bg-gradient-to-r from-red-400 to-red-700 drop-shadow-md -skew-x-6 mb-4 mt-8 p-3"
   
   return (
     <h2

--- a/src/components/markup/H3.jsx
+++ b/src/components/markup/H3.jsx
@@ -1,5 +1,5 @@
 const H3 = ({ children }) => {
-  const style = "text-3xl font-heading p-3"
+  const style = "text-3xl text-gray-900 drop-shadow-md font-heading p-3"
   
   return (
     <h3 className={style}>

--- a/src/components/markup/List.jsx
+++ b/src/components/markup/List.jsx
@@ -1,6 +1,6 @@
 const List = ({ children }) => {
   const borderDiv = "bg-gradient-to-r from-red-500 to-transparent w-fit my-4 mx-auto py-1 px-0"
-  const style = "text-left md:text-lg py-3 px-12 bg-gray-900 h-full w-full" 
+  const style = "text-left text-black md:text-lg py-3 px-12 bg-gray-100 h-full w-full" 
   const itemStyle = "list-disc p-1"
 
   const createListItems = () => {

--- a/src/components/markup/P.jsx
+++ b/src/components/markup/P.jsx
@@ -1,5 +1,5 @@
-const P = ({ children }) => {
-  const style = "md:text-lg py-2 mx-auto md:w-4/5"
+const P = ({ children, light }) => {
+  const style = `md:text-lg font-body ${light ? 'text-gray-100' : 'text-gray-900'} py-2 mx-auto md:w-4/5`
   
   return (
     <p className={style}>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -30,7 +30,7 @@ const Home = () => {
           annual Carolina Reaper Road Race.
         </P>
         <CategoryContainer />
-        <CtaButton />
+        <CtaButton dark/>
         <H2>Registration Fees</H2>
         <List>
           {[
@@ -68,7 +68,7 @@ const Home = () => {
         <P>
           * Age categories are determined by age of participant on race day. *
         </P>
-        <CtaButton />
+        <CtaButton dark/>
         <P>
           Stay in town for a fun social skate on the scenic Swamp Rabbit Trail
           on Sunday.

--- a/src/pages/RaceInfo.jsx
+++ b/src/pages/RaceInfo.jsx
@@ -89,7 +89,7 @@ const RaceInfo = () => {
         from 8:00am - 9:00am and will cost an additional
         $10 per category.
       </P>
-      <CtaButton />
+      <CtaButton dark/>
       <H2 id="relay">Relay Info</H2>
       <P>Team up with your friends to complete the Moreathon!</P>
       <List>


### PR DESCRIPTION
Closes #6 
Flip BG and text colors to try light BG and dark text. 
Added `dark` prop to `CtaButton` and `light` prop to `P`
Added some shadow to help certain elements stand out. 